### PR TITLE
Remove .setTitle

### DIFF
--- a/wearapp/src/main/java/com/thewizrd/simpleweather/wearable/complications/AQIComplicationService.kt
+++ b/wearapp/src/main/java/com/thewizrd/simpleweather/wearable/complications/AQIComplicationService.kt
@@ -98,10 +98,10 @@ class AQIComplicationService : BaseWeatherComplicationService() {
                     ).build()
                 ).setText(
                     PlainComplicationText.Builder("57").build()
-                ).setTitle(
+                )/*.setTitle(
                     PlainComplicationText.Builder(getString(R.string.label_airquality_short))
                         .build()
-                ).build()
+                )*/.build()
             }
             ComplicationType.SHORT_TEXT -> {
                 ShortTextComplicationData.Builder(
@@ -112,18 +112,18 @@ class AQIComplicationService : BaseWeatherComplicationService() {
                         Icon.createWithResource(this, complicationIconResId)
                             .setTint(Colors.WHITESMOKE)
                     ).build()
-                ).setTitle(
+                )/*.setTitle(
                     PlainComplicationText.Builder(getString(R.string.label_airquality_short))
                         .build()
-                ).build()
+                )*/.build()
             }
             ComplicationType.LONG_TEXT -> {
                 LongTextComplicationData.Builder(
                     PlainComplicationText.Builder("Air Quality").build(),
                     PlainComplicationText.Builder("Air Quality: 57, Moderate").build()
-                ).setTitle(
+                )/*.setTitle(
                     PlainComplicationText.Builder("57, Moderate").build()
-                ).setMonochromaticImage(
+                )*/.setMonochromaticImage(
                     MonochromaticImage.Builder(
                         Icon.createWithResource(this, complicationIconResId)
                             .setTint(Colors.WHITESMOKE)
@@ -159,10 +159,10 @@ class AQIComplicationService : BaseWeatherComplicationService() {
                     ).build()
                 ).setText(
                     PlainComplicationText.Builder(aqiIndex.toString()).build()
-                ).setTitle(
+                )/*.setTitle(
                     PlainComplicationText.Builder(getString(R.string.label_airquality_short))
                         .build()
-                ).setTapAction(
+                )*/.setTapAction(
                     getTapIntent(this)
                 ).build()
             }
@@ -177,10 +177,11 @@ class AQIComplicationService : BaseWeatherComplicationService() {
                         Icon.createWithResource(this, complicationIconResId)
                             .setTint(Colors.WHITESMOKE)
                     ).build()
-                ).setTitle(
+                )/*.setTitle(
                     PlainComplicationText.Builder(getString(R.string.label_airquality_short))
                         .build()
-                ).setTapAction(
+                )*/
+                .setTapAction(
                     getTapIntent(this)
                 ).build()
             }
@@ -191,9 +192,9 @@ class AQIComplicationService : BaseWeatherComplicationService() {
                     PlainComplicationText.Builder(
                         "${getString(R.string.label_airquality_short)}: $aqiIndex, ${aqiModel.level}"
                     ).build()
-                ).setTitle(
+                )/*.setTitle(
                     PlainComplicationText.Builder("$aqiIndex, ${aqiModel.level}").build()
-                ).setMonochromaticImage(
+                )*/.setMonochromaticImage(
                     MonochromaticImage.Builder(
                         Icon.createWithResource(this, complicationIconResId)
                             .setTint(Colors.WHITESMOKE)

--- a/wearapp/src/main/java/com/thewizrd/simpleweather/wearable/complications/BeaufortComplicationService.kt
+++ b/wearapp/src/main/java/com/thewizrd/simpleweather/wearable/complications/BeaufortComplicationService.kt
@@ -40,9 +40,9 @@ class BeaufortComplicationService : WeatherHourlyForecastComplicationService() {
                     ).build()
                 ).setText(
                     PlainComplicationText.Builder("3").build()
-                ).setTitle(
+                )/*.setTitle(
                     PlainComplicationText.Builder("Beaufort").build()
-                ).build()
+                )*/.build()
             }
             ComplicationType.SHORT_TEXT -> {
                 ShortTextComplicationData.Builder(
@@ -53,17 +53,17 @@ class BeaufortComplicationService : WeatherHourlyForecastComplicationService() {
                         Icon.createWithResource(this, complicationIconResId)
                             .setTint(Colors.WHITESMOKE)
                     ).build()
-                ).setTitle(
+                )/*.setTitle(
                     PlainComplicationText.Builder("Beaufort").build()
-                ).build()
+                )*/.build()
             }
             ComplicationType.LONG_TEXT -> {
                 LongTextComplicationData.Builder(
                     PlainComplicationText.Builder("Beaufort").build(),
                     PlainComplicationText.Builder("Beaufort: 3, Gentle Breeze").build()
-                ).setTitle(
+                )/*.setTitle(
                     PlainComplicationText.Builder("3, Gentle Breeze").build()
-                ).setMonochromaticImage(
+                )*/.setMonochromaticImage(
                     MonochromaticImage.Builder(
                         Icon.createWithResource(this, complicationIconResId)
                             .setTint(Colors.WHITESMOKE)
@@ -104,9 +104,9 @@ class BeaufortComplicationService : WeatherHourlyForecastComplicationService() {
                     ).build()
                 ).setText(
                     PlainComplicationText.Builder(beaufortModel.progress.toString()).build()
-                ).setTitle(
+                )/*.setTitle(
                     PlainComplicationText.Builder(beaufortModel.beaufort.label).build()
-                ).setTapAction(
+                )*/.setTapAction(
                     getTapIntent(this)
                 ).build()
             }
@@ -121,9 +121,9 @@ class BeaufortComplicationService : WeatherHourlyForecastComplicationService() {
                         Icon.createWithResource(this, complicationIconResId)
                             .setTint(Colors.WHITESMOKE)
                     ).build()
-                ).setTitle(
+                )/*.setTitle(
                     PlainComplicationText.Builder(beaufortModel.beaufort.label).build()
-                ).setTapAction(
+                )*/.setTapAction(
                     getTapIntent(this)
                 ).build()
             }
@@ -133,11 +133,11 @@ class BeaufortComplicationService : WeatherHourlyForecastComplicationService() {
                     PlainComplicationText.Builder(
                         "${beaufortModel.beaufort.label}: ${beaufortModel.progress}, ${beaufortModel.beaufort.value}"
                     ).build()
-                ).setTitle(
+                )/*.setTitle(
                     PlainComplicationText.Builder(
                         "${beaufortModel.progress}, ${beaufortModel.beaufort.value}"
                     ).build()
-                ).setMonochromaticImage(
+                )*/.setMonochromaticImage(
                     MonochromaticImage.Builder(
                         Icon.createWithResource(this, complicationIconResId)
                             .setTint(Colors.WHITESMOKE)

--- a/wearapp/src/main/java/com/thewizrd/simpleweather/wearable/complications/FeelsLikeComplicationService.kt
+++ b/wearapp/src/main/java/com/thewizrd/simpleweather/wearable/complications/FeelsLikeComplicationService.kt
@@ -34,17 +34,17 @@ class FeelsLikeComplicationService : WeatherHourlyForecastComplicationService() 
                         Icon.createWithResource(this, complicationIconResId)
                             .setTint(Colors.WHITESMOKE)
                     ).build()
-                ).setTitle(
+                )/*.setTitle(
                     PlainComplicationText.Builder(getString(R.string.label_feelslike)).build()
-                ).build()
+                )*/.build()
             }
             ComplicationType.LONG_TEXT -> {
                 LongTextComplicationData.Builder(
                     PlainComplicationText.Builder(getString(R.string.label_feelslike)).build(),
                     PlainComplicationText.Builder("Feels like: 75°").build()
-                ).setTitle(
+                )/*.setTitle(
                     PlainComplicationText.Builder("75°").build()
-                ).setMonochromaticImage(
+                )*/.setMonochromaticImage(
                     MonochromaticImage.Builder(
                         Icon.createWithResource(this, complicationIconResId)
                             .setTint(Colors.WHITESMOKE)
@@ -90,9 +90,9 @@ class FeelsLikeComplicationService : WeatherHourlyForecastComplicationService() 
                         Icon.createWithResource(this, complicationIconResId)
                             .setTint(Colors.WHITESMOKE)
                     ).build()
-                ).setTitle(
+                )/*.setTitle(
                     PlainComplicationText.Builder(getString(R.string.label_feelslike)).build()
-                ).build()
+                )*/.build()
             }
             ComplicationType.LONG_TEXT -> {
                 LongTextComplicationData.Builder(
@@ -100,9 +100,9 @@ class FeelsLikeComplicationService : WeatherHourlyForecastComplicationService() 
                     PlainComplicationText.Builder(
                         String.format("%s: %s", getString(R.string.label_feelslike), tempStr)
                     ).build()
-                ).setTitle(
+                )/*.setTitle(
                     PlainComplicationText.Builder(tempStr).build()
-                ).setMonochromaticImage(
+                )*/.setMonochromaticImage(
                     MonochromaticImage.Builder(
                         Icon.createWithResource(this, complicationIconResId)
                             .setTint(Colors.WHITESMOKE)

--- a/wearapp/src/main/java/com/thewizrd/simpleweather/wearable/complications/HumidityComplicationService.kt
+++ b/wearapp/src/main/java/com/thewizrd/simpleweather/wearable/complications/HumidityComplicationService.kt
@@ -50,18 +50,18 @@ class HumidityComplicationService : WeatherHourlyForecastComplicationService() {
                         Icon.createWithResource(this, complicationIconResId)
                             .setTint(Colors.WHITESMOKE)
                     ).build()
-                ).setTitle(
+                )/*.setTitle(
                     PlainComplicationText.Builder(getString(R.string.label_humidity)).build()
-                ).build()
+                )*/.build()
             }
             ComplicationType.LONG_TEXT -> {
                 LongTextComplicationData.Builder(
                     PlainComplicationText.Builder(getString(R.string.label_humidity)).build(),
                     PlainComplicationText.Builder("${getString(R.string.label_humidity)}: 75%")
                         .build()
-                ).setTitle(
+                )/*.setTitle(
                     PlainComplicationText.Builder("75%").build()
-                ).setMonochromaticImage(
+                )*/.setMonochromaticImage(
                     MonochromaticImage.Builder(
                         Icon.createWithResource(this, complicationIconResId)
                             .setTint(Colors.WHITESMOKE)
@@ -115,9 +115,9 @@ class HumidityComplicationService : WeatherHourlyForecastComplicationService() {
                         Icon.createWithResource(this, complicationIconResId)
                             .setTint(Colors.WHITESMOKE)
                     ).build()
-                ).setTitle(
+                )/*.setTitle(
                     PlainComplicationText.Builder(getString(R.string.label_humidity)).build()
-                ).setTapAction(
+                )*/.setTapAction(
                     getTapIntent(this)
                 ).build()
             }
@@ -127,9 +127,9 @@ class HumidityComplicationService : WeatherHourlyForecastComplicationService() {
                     PlainComplicationText.Builder(
                         "${getString(R.string.label_humidity)}: ${humidityPct}%"
                     ).build()
-                ).setTitle(
+                )/*.setTitle(
                     PlainComplicationText.Builder("${humidityPct}%").build()
-                ).setMonochromaticImage(
+                )*/.setMonochromaticImage(
                     MonochromaticImage.Builder(
                         Icon.createWithResource(this, complicationIconResId)
                             .setTint(Colors.WHITESMOKE)

--- a/wearapp/src/main/java/com/thewizrd/simpleweather/wearable/complications/PrecipitationComplicationService.kt
+++ b/wearapp/src/main/java/com/thewizrd/simpleweather/wearable/complications/PrecipitationComplicationService.kt
@@ -48,17 +48,17 @@ class PrecipitationComplicationService : WeatherHourlyForecastComplicationServic
                         Icon.createWithResource(this, complicationIconResId)
                             .setTint(Colors.WHITESMOKE)
                     ).build()
-                ).setTitle(
+                )/*.setTitle(
                     PlainComplicationText.Builder(getString(R.string.label_chance)).build()
-                ).build()
+                )*/.build()
             }
             ComplicationType.LONG_TEXT -> {
                 LongTextComplicationData.Builder(
                     PlainComplicationText.Builder("Chance").build(),
                     PlainComplicationText.Builder("Chance: 50%").build()
-                ).setTitle(
+                )/*.setTitle(
                     PlainComplicationText.Builder("50%").build()
-                ).setMonochromaticImage(
+                )*/.setMonochromaticImage(
                     MonochromaticImage.Builder(
                         Icon.createWithResource(this, complicationIconResId)
                             .setTint(Colors.WHITESMOKE)
@@ -109,9 +109,9 @@ class PrecipitationComplicationService : WeatherHourlyForecastComplicationServic
                         Icon.createWithResource(this, complicationIconResId)
                             .setTint(Colors.WHITESMOKE)
                     ).build()
-                ).setTitle(
+                )/*.setTitle(
                     PlainComplicationText.Builder(getString(R.string.label_chance)).build()
-                ).setTapAction(
+                )*/.setTapAction(
                     getTapIntent(this)
                 ).build()
             }
@@ -121,9 +121,9 @@ class PrecipitationComplicationService : WeatherHourlyForecastComplicationServic
                     PlainComplicationText.Builder(
                         "${getString(R.string.label_chance)}: ${popChance}%"
                     ).build()
-                ).setTitle(
+                )/*.setTitle(
                     PlainComplicationText.Builder("${popChance}%").build()
-                ).setMonochromaticImage(
+                )*/.setMonochromaticImage(
                     MonochromaticImage.Builder(
                         Icon.createWithResource(this, complicationIconResId)
                             .setTint(Colors.WHITESMOKE)

--- a/wearapp/src/main/java/com/thewizrd/simpleweather/wearable/complications/UVComplicationService.kt
+++ b/wearapp/src/main/java/com/thewizrd/simpleweather/wearable/complications/UVComplicationService.kt
@@ -39,9 +39,9 @@ class UVComplicationService : WeatherHourlyForecastComplicationService() {
                     ).build()
                 ).setText(
                     PlainComplicationText.Builder("3").build()
-                ).setTitle(
+                )/*.setTitle(
                     PlainComplicationText.Builder(getString(R.string.label_uv)).build()
-                ).build()
+                )*/.build()
             }
             ComplicationType.SHORT_TEXT -> {
                 ShortTextComplicationData.Builder(
@@ -52,17 +52,17 @@ class UVComplicationService : WeatherHourlyForecastComplicationService() {
                         Icon.createWithResource(this, complicationIconResId)
                             .setTint(Colors.WHITESMOKE)
                     ).build()
-                ).setTitle(
+                )/*.setTitle(
                     PlainComplicationText.Builder(getString(R.string.label_uv)).build()
-                ).build()
+                )*/.build()
             }
             ComplicationType.LONG_TEXT -> {
                 LongTextComplicationData.Builder(
                     PlainComplicationText.Builder(getString(R.string.label_uv)).build(),
                     PlainComplicationText.Builder("UV Index: 3, Moderate").build()
-                ).setTitle(
+                )/*.setTitle(
                     PlainComplicationText.Builder("3, Moderate").build()
-                ).setMonochromaticImage(
+                )*/.setMonochromaticImage(
                     MonochromaticImage.Builder(
                         Icon.createWithResource(this, complicationIconResId)
                             .setTint(Colors.WHITESMOKE)
@@ -101,9 +101,9 @@ class UVComplicationService : WeatherHourlyForecastComplicationService() {
                     ).build()
                 ).setText(
                     PlainComplicationText.Builder(uvModel.index.toString()).build()
-                ).setTitle(
+                )/*.setTitle(
                     PlainComplicationText.Builder(getString(R.string.label_uv)).build()
-                ).setTapAction(
+                )*/.setTapAction(
                     getTapIntent(this)
                 ).build()
             }
@@ -118,9 +118,9 @@ class UVComplicationService : WeatherHourlyForecastComplicationService() {
                         Icon.createWithResource(this, complicationIconResId)
                             .setTint(Colors.WHITESMOKE)
                     ).build()
-                ).setTitle(
+                )/*.setTitle(
                     PlainComplicationText.Builder(getString(R.string.label_uv)).build()
-                ).setTapAction(
+                )*/.setTapAction(
                     getTapIntent(this)
                 ).build()
             }
@@ -130,10 +130,10 @@ class UVComplicationService : WeatherHourlyForecastComplicationService() {
                     PlainComplicationText.Builder(
                         "${getString(R.string.label_uv)}: ${uvModel.index}, ${uvModel.description}"
                     ).build()
-                ).setTitle(
+                )/*.setTitle(
                     PlainComplicationText.Builder("${uvModel.index}, ${uvModel.description}")
                         .build()
-                ).setMonochromaticImage(
+                )*/.setMonochromaticImage(
                     MonochromaticImage.Builder(
                         Icon.createWithResource(this, complicationIconResId)
                             .setTint(Colors.WHITESMOKE)

--- a/wearapp/src/main/java/com/thewizrd/simpleweather/wearable/complications/WeatherHiLoComplicationService.kt
+++ b/wearapp/src/main/java/com/thewizrd/simpleweather/wearable/complications/WeatherHiLoComplicationService.kt
@@ -35,9 +35,9 @@ class WeatherHiLoComplicationService : WeatherForecastComplicationService() {
                 ShortTextComplicationData.Builder(
                     PlainComplicationText.Builder("70°").build(),
                     PlainComplicationText.Builder("70° - Sunny").build()
-                ).setTitle(
+                )/*.setTitle(
                     PlainComplicationText.Builder("75° | 65°").build()
-                ).setMonochromaticImage(
+                )*/.setMonochromaticImage(
                     MonochromaticImage.Builder(
                         Icon.createWithResource(this, complicationIconResId)
                             .setTint(Colors.WHITESMOKE)
@@ -48,9 +48,9 @@ class WeatherHiLoComplicationService : WeatherForecastComplicationService() {
                 LongTextComplicationData.Builder(
                     PlainComplicationText.Builder("70° - Sunny").build(),
                     PlainComplicationText.Builder("70° - Sunny").build()
-                ).setTitle(
+                )/*.setTitle(
                     PlainComplicationText.Builder("75° | 65°").build()
-                ).setMonochromaticImage(
+                )*/.setMonochromaticImage(
                     MonochromaticImage.Builder(
                         Icon.createWithResource(this, complicationIconResId)
                             .setTint(Colors.WHITESMOKE)
@@ -178,9 +178,9 @@ class WeatherHiLoComplicationService : WeatherForecastComplicationService() {
                 val builder = LongTextComplicationData.Builder(
                     PlainComplicationText.Builder("$temp - $condition").build(),
                     PlainComplicationText.Builder("$temp - $condition").build()
-                ).setTitle(
+                )/*.setTitle(
                     PlainComplicationText.Builder("$hiTemp | $loTemp").build()
-                )
+                )*/
 
                 // Weather Icon
                 if (wim.isFontIcon) {

--- a/wearapp/src/main/java/com/thewizrd/simpleweather/wearable/complications/WindComplicationService.kt
+++ b/wearapp/src/main/java/com/thewizrd/simpleweather/wearable/complications/WindComplicationService.kt
@@ -41,16 +41,16 @@ class WindComplicationService : WeatherHourlyForecastComplicationService() {
                             )
                         )
                     ).build()
-                ).setTitle(
-                    PlainComplicationText.Builder(getString(R.string.label_wind)).build()
+                )/*.setTitle(
+                    PlainComplicationText.Builder(getString(R.string.label_wind)).build()*/
                 ).build()
             }
             ComplicationType.LONG_TEXT -> {
                 LongTextComplicationData.Builder(
                     PlainComplicationText.Builder("Wind").build(),
                     PlainComplicationText.Builder("Wind: 5 mph, SSE").build()
-                ).setTitle(
-                    PlainComplicationText.Builder("5 mph, SSE").build()
+                )/*.setTitle(
+                    PlainComplicationText.Builder("5 mph, SSE").build()*/
                 ).setMonochromaticImage(
                     MonochromaticImage.Builder(
                         Icon.createWithResource(this, complicationIconResId)
@@ -129,8 +129,8 @@ class WindComplicationService : WeatherHourlyForecastComplicationService() {
                             )
                         )
                     ).build()
-                ).setTitle(
-                    PlainComplicationText.Builder(getString(R.string.label_wind)).build()
+                )/*.setTitle(
+                    PlainComplicationText.Builder(getString(R.string.label_wind)).build()*/
                 ).setTapAction(
                     getTapIntent(this)
                 ).build()
@@ -139,8 +139,8 @@ class WindComplicationService : WeatherHourlyForecastComplicationService() {
                 LongTextComplicationData.Builder(
                     PlainComplicationText.Builder(getString(R.string.label_wind)).build(),
                     PlainComplicationText.Builder(windSpeedLong).build()
-                ).setTitle(
-                    PlainComplicationText.Builder(windSpeedLong).build()
+                )/*.setTitle(
+                    PlainComplicationText.Builder(windSpeedLong).build()*/
                 ).setMonochromaticImage(
                     MonochromaticImage.Builder(
                         Icon.createWithResource(this, complicationIconResId)

--- a/wearapp/src/main/java/com/thewizrd/simpleweather/wearable/complications/WindComplicationService.kt
+++ b/wearapp/src/main/java/com/thewizrd/simpleweather/wearable/complications/WindComplicationService.kt
@@ -42,16 +42,16 @@ class WindComplicationService : WeatherHourlyForecastComplicationService() {
                         )
                     ).build()
                 )/*.setTitle(
-                    PlainComplicationText.Builder(getString(R.string.label_wind)).build()*/
-                ).build()
+                    PlainComplicationText.Builder(getString(R.string.label_wind)).build()
+                )*/.build()
             }
             ComplicationType.LONG_TEXT -> {
                 LongTextComplicationData.Builder(
                     PlainComplicationText.Builder("Wind").build(),
                     PlainComplicationText.Builder("Wind: 5 mph, SSE").build()
                 )/*.setTitle(
-                    PlainComplicationText.Builder("5 mph, SSE").build()*/
-                ).setMonochromaticImage(
+                    PlainComplicationText.Builder("5 mph, SSE").build()
+                )*/.setMonochromaticImage(
                     MonochromaticImage.Builder(
                         Icon.createWithResource(this, complicationIconResId)
                             .setTint(Colors.WHITESMOKE)
@@ -130,8 +130,8 @@ class WindComplicationService : WeatherHourlyForecastComplicationService() {
                         )
                     ).build()
                 )/*.setTitle(
-                    PlainComplicationText.Builder(getString(R.string.label_wind)).build()*/
-                ).setTapAction(
+                    PlainComplicationText.Builder(getString(R.string.label_wind)).build()
+                )*/.setTapAction(
                     getTapIntent(this)
                 ).build()
             }
@@ -140,8 +140,8 @@ class WindComplicationService : WeatherHourlyForecastComplicationService() {
                     PlainComplicationText.Builder(getString(R.string.label_wind)).build(),
                     PlainComplicationText.Builder(windSpeedLong).build()
                 )/*.setTitle(
-                    PlainComplicationText.Builder(windSpeedLong).build()*/
-                ).setMonochromaticImage(
+                    PlainComplicationText.Builder(windSpeedLong).build()
+                )*/.setMonochromaticImage(
                     MonochromaticImage.Builder(
                         Icon.createWithResource(this, complicationIconResId)
                             .setTint(Colors.WHITESMOKE)


### PR DESCRIPTION
We don't need to see title in custom complications often. 5mph / 'Wind' is not as good as 5mph + Wind Icon. By removing .setTitle, we can force watch face to use Text + Icon layout which is always a better option.

This also applies to AQI, Beaufort, Chance of Rain, Feels like, Humidity, UV Index