### PR TITLE
Fix parsing of BrightSky/DWD Json data

### DIFF
--- a/weather-api/src/main/java/com/thewizrd/weather_api/brightsky/CurrentResponse.kt
+++ b/weather-api/src/main/java/com/thewizrd/weather_api/brightsky/CurrentResponse.kt
@@ -147,6 +147,7 @@ data class SourcesItem(
     var height: Float? = null
 )
 
+@JsonClass(generateAdapter = true)
 data class FallbackSourceIds(
     var any: Any? = null
 )


### PR DESCRIPTION
This fixes issue #19
Looks like proguard strips away essential information needed to parse the json data